### PR TITLE
Dt 820 rail to nebula

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,8 @@ ENV PORT=8080
 ENV ROUTER_ZIP_URL=http://beta.digitransit.fi/routing-data/v1/router-finland.zip
 
 CMD python app.py
+RUN chmod -R 777 $root
+USER 9999
+
+EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ADD . $root
 ENV PORT=8080
 ENV ROUTER_ZIP_URL=http://beta.digitransit.fi/routing-data/v1/router-finland.zip
 
-CMD python app.py
 RUN chmod -R 777 $root
 USER 9999
 
 EXPOSE 8080
 
+CMD export TZ="Europe/Helsinki" && python app.py


### PR DESCRIPTION
If you want to test, first:

delete existing app from nebula openshift by:

oc delete all -l <label_name>

then:

Build docker image,
Push to dockerhub,

Create new nebula app directly from dockerhub image: 
oc new-app <image-name>:<tag> -e ROUTER_ZIP_URL=url_to_otp_data_container/router-finland-zip,

expose the raildigitraffic service:

oc expose service/<service_name> --hostname=<your_selected_hostname>
